### PR TITLE
send initial high is too short: 0.05 sec -> 0.6 sec

### DIFF
--- a/dht11/__init__.py
+++ b/dht11/__init__.py
@@ -34,7 +34,7 @@ class DHT11:
         RPi.GPIO.setup(self.__pin, RPi.GPIO.OUT)
 
         # send initial high
-        self.__send_and_sleep(RPi.GPIO.HIGH, 0.05)
+        self.__send_and_sleep(RPi.GPIO.HIGH, 0.6)
 
         # pull down to low
         self.__send_and_sleep(RPi.GPIO.LOW, 0.02)


### PR DESCRIPTION
We cannot use this lib on raspberry pi 4. Maybe, send initial high in 0.05 sec is too short. I changed it to 0.6 sec.
